### PR TITLE
Small improvement in header layout

### DIFF
--- a/administrator/components/com_joomgallery/layouts/joomgallery/common/header.bootone.php
+++ b/administrator/components/com_joomgallery/layouts/joomgallery/common/header.bootone.php
@@ -133,10 +133,14 @@ JHtml::register('joomgallery.tip', array('JHtmlJoomGalleryBootone', 'tip'));
     </div>
     <div class="span6">
 <?php if($displayData->params->get('show_header_search')): ?>
-      <form action="<?php echo JRoute::_('index.php?view=search'); ?>" method="post" class="navbar-search pull-right">
-        <label for="jg-search-box" class="sr-only hidden"><?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?></label>
-        <input title="<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?>" type="text" name="sstring" id="jg-search-box" class="search-query form-control" onblur="if(this.value=='') this.value='<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH', true); ?>';" onfocus="if(this.value=='<?php echo  JText::_('COM_JOOMGALLERY_COMMON_SEARCH', true); ?>') this.value='';" value="<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?>" placeholder="<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?>" />
-      </form>
+      <div class="row-fluid">
+        <div class="span12">
+          <form action="<?php echo JRoute::_('index.php?view=search'); ?>" method="post" class="navbar-search pull-right">
+            <label for="jg-search-box" class="sr-only hidden"><?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?></label>
+            <input title="<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?>" type="text" name="sstring" id="jg-search-box" class="search-query form-control" onblur="if(this.value=='') this.value='<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH', true); ?>';" onfocus="if(this.value=='<?php echo  JText::_('COM_JOOMGALLERY_COMMON_SEARCH', true); ?>') this.value='';" value="<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?>" placeholder="<?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH'); ?>" />
+          </form>
+        </div>
+      </div>
 <?php endif;
       if($displayData->params->get('show_header_allpics', 1) || $displayData->params->get('show_header_allhits', 0)): ?>
       <div class="row-fluid">


### PR DESCRIPTION
A small tweak for the header layout.

Before patch:
![vorher](https://cloud.githubusercontent.com/assets/10573985/8258783/0f9ac576-16b8-11e5-8e4e-5a476a54132f.jpg)

After patch:
![nachher](https://cloud.githubusercontent.com/assets/10573985/8258788/1d66fa4e-16b8-11e5-9c88-8b9125c587f8.jpg)
