### PR TITLE
Improve the display of the star rating

### DIFF
--- a/components/com_joomgallery/views/category/tmpl/bootone_images.php
+++ b/components/com_joomgallery/views/category/tmpl/bootone_images.php
@@ -37,7 +37,7 @@
         <div class="thumbnail">
           <a <?php echo $row->atagtitle; ?> href="<?php echo $row->link; ?>">
             <img src="<?php echo $row->thumb_src; ?>" <?php echo $row->imgwh; ?> alt="<?php echo $row->imgtitle; ?>" /></a>
-          <div class="caption jg_catelem_txt">
+          <div class="caption">
             <ul class="unstyled text-center">
 <?php     if($this->_config->get('jg_showtitle') || ($this->_config->get('jg_showpicasnew') && $row->isnew)): ?>
               <li>

--- a/media/joomgallery/css/bootone.css
+++ b/media/joomgallery/css/bootone.css
@@ -109,3 +109,7 @@
   background-repeat:no-repeat !important;
   background-position:center !important;  
 }
+
+.jg_starrating_cat, .jg_starrating_fav, .jg_starrating_top, .jg_starrating_search{
+	margin:0 auto;
+}


### PR DESCRIPTION
This pull request corrects the alignment of the star rating display and removes the class `jg_catelem_txt` from the text elements of the images in the category view.
