### PR TITLE
Replace images with icomoon fonts

### DIFF
--- a/administrator/components/com_joomgallery/layouts/joomgallery/common/footer.bootone.php
+++ b/administrator/components/com_joomgallery/layouts/joomgallery/common/footer.bootone.php
@@ -11,8 +11,9 @@
     <div class="span6">
  <?php if($displayData->params->get('show_rmsm_legend')): ?>
       <div class="text-muted">
-        <?php echo JHtml::_('joomgallery.icon', 'group_key.png', 'COM_JOOMGALLERY_COMMON_TIP_YOU_NOT_ACCESS_THIS_CATEGORY'); ?>
-        <?php echo  JText::_('COM_JOOMGALLERY_COMMON_RESTRICTED_CATEGORIES'); ?>
+        <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_TIP_YOU_NOT_ACCESS_THIS_CATEGORY', 'COM_JOOMGALLERY_COMMON_RESTRICTED_CATEGORIES', true); ?>>
+        <span class="icon-locked"></span>
+        <?php echo JText::_('COM_JOOMGALLERY_COMMON_RESTRICTED_CATEGORIES'); ?></span>
       </div>
 <?php endif;
       if($displayData->params->get('show_footer_backlink')): ?>

--- a/administrator/components/com_joomgallery/layouts/joomgallery/common/header.bootone.php
+++ b/administrator/components/com_joomgallery/layouts/joomgallery/common/header.bootone.php
@@ -35,15 +35,14 @@
       <ul class="unstyled jg-links-header">
 <?php    if($displayData->params->get('show_mygal')): ?>
         <li class="jg-userpanel-link">
-          <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&view=userpanel'); ?>"<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_USER_PANEL', null, true); ?>">
-            <span class="icon-upload"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL') ;?>
-          </a>
+          <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&view=userpanel'); ?>"<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_USER_PANEL', null, true);?>>
+            <span class="icon-user"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL') ;?></a>
         </li>
 <?php   endif;
         if($displayData->params->get('show_mygal_no_access')): ?>
         <li class="jg-userpanel-link">
           <span class="text-muted<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_MSG_YOU_ARE_NOT_LOGGED', 'COM_JOOMGALLERY_COMMON_USER_PANEL'); ?>">
-            <span class="icon-upload"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL'); ?>
+            <span class="icon-user"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL'); ?>
           </span>
         </li>
 <?php   endif;
@@ -51,14 +50,12 @@
         <li class="jg-favourites-link">
     <?php switch($displayData->params->get('show_favourites')):
             case 1: ?>
-          <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&view=favourites'); ?>"<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_MY', true); ?>">
-            <span class="icon-basket"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_DOWNLOADZIP_MY'); ?>
-          </a>
+          <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&view=favourites'); ?>"<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_MY', true); ?>>
+            <span class="icon-basket"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_DOWNLOADZIP_MY'); ?></a>
       <?php break;
             case 2: ?>
-          <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&view=favourites'); ?>"<?php echo JHtml::_('joomgallery.tip', $displayData->params->get('favourites_tooltip_text'), JText::_('COM_JOOMGALLERY_COMMON_FAVOURITES_MY'), true, false); ?>">
-           <span class="icon-star"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_FAVOURITES_MY'); ?>
-          </a>
+          <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&view=favourites'); ?>"<?php echo JHtml::_('joomgallery.tip', $displayData->params->get('favourites_tooltip_text'), JText::_('COM_JOOMGALLERY_COMMON_FAVOURITES_MY'), true, false); ?>>
+           <span class="icon-star"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_FAVOURITES_MY'); ?></a>
       <?php break;
             case 3: ?>
           <span class="text-muted<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_DOWNLOAD_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_MY'); ?>">
@@ -66,14 +63,13 @@
           </span>
       <?php break;
             case 4: ?>
-          <span class="text-muted<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_MYCOM_JOOMGALLERY_COMMON_FAVOURITES_DOWNLOAD_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_MY'); ?>">
+          <span class="text-muted<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_DOWNLOAD_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_MY'); ?>">
             <span class="icon-star"></span> <?php echo JText::_('COM_JOOMGALLERY_COMMON_FAVOURITES_MY'); ?>
           </span>
       <?php break;
             case 5: ?>
-          <a href="<?php echo JRoute::_('index.php?task=favourites.createzip'); ?>"<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_DOWNLOADZIP_CREATE_TIPTEXT', 'COM_JOOMGALLERY_DOWNLOADZIP_DOWNLOAD', true); ?>">
-            <span class="icon-out"></span> <?php echo JText::_('COM_JOOMGALLERY_DOWNLOADZIP_DOWNLOAD'); ?>
-          </a>
+          <a href="<?php echo JRoute::_('index.php?task=favourites.createzip'); ?>"<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_DOWNLOADZIP_CREATE_TIPTEXT', 'COM_JOOMGALLERY_DOWNLOADZIP_DOWNLOAD', true); ?>>
+            <span class="icon-out"></span> <?php echo JText::_('COM_JOOMGALLERY_DOWNLOADZIP_DOWNLOAD'); ?></a>
       <?php break;
           endswitch; ?>
         </li>

--- a/components/com_joomgallery/views/category/tmpl/bootone_head.php
+++ b/components/com_joomgallery/views/category/tmpl/bootone_head.php
@@ -9,35 +9,33 @@
         <div class="span2 text-right">
 <?php   if($this->params->get('show_feed_icon')): ?>
           <a href="<?php echo $this->params->get('feed_url'); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_CATEGORY_FEED_TIPTEXT', 'COM_JOOMGALLERY_CATEGORY_FEED_TIPCAPTION', true); ?>>
-            <?php echo JHtml::_('joomgallery.icon', 'feed.png', 'COM_JOOMGALLERY_CATEGORY_FEED_TIPCAPTION'); ?>
-          </a>
+            <span class="icon-feed"></span></a>
 <?php   $this->params->set('show_feed_icon', 0);
         endif;
         if($this->params->get('show_headerfavourites_icon')): ?>
 <?php     if($this->params->get('show_headerfavourites_icon') == 1): ?>
           <a href="<?php echo JRoute::_('index.php?task=favourites.addimages&catid='.$this->category->cid); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION', true); ?>>
-            <?php echo JHTML::_('joomgallery.icon', 'star.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION'); ?></a>
+            <span class="icon-star"></span></a>
 <?php     endif;
           if($this->params->get('show_headerfavourites_icon') == 2): ?>
           <a href="<?php echo JRoute::_('index.php?task=favourites.addimages&catid='.$this->category->cid); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION', true); ?>>
-            <?php echo JHTML::_('joomgallery.icon', 'basket_put.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION'); ?></a>
+            <span class="icon-star"></span></a>
 <?php     endif;
           if($this->params->get('show_headerfavourites_icon') == -1): ?>
           <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION', true); ?>>
-            <?php echo JHTML::_('joomgallery.icon', 'star_gr.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION'); ?>
+            <span class="icon-star-empty"></span>
           </span>
 <?php     endif;
           if($this->params->get('show_headerfavourites_icon') == -2): ?>
           <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION', true); ?>>
-            <?php echo JHTML::_('joomgallery.icon', 'basket_put_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION'); ?>
+            <span class="icon-star-empty"></span>
           </span>
 <?php     endif; ?>
 <?php   endif;
         if($this->params->get('show_upload_icon')):
           JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
           <a href="<?php echo JRoute::_('index.php?view=mini&format=raw&upload_category='.$this->category->cid); ?>" class="jg-bootone-modal<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPTEXT', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?>" rel="{handler: 'iframe', size: {x: 620, y: 550}}">
-            <?php echo JHtml::_('joomgallery.icon', 'add.png', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?>
-          </a>
+            <span class="icon-plus-circle"></span></a>
 <?php     $this->params->set('show_upload_icon', 0);
         endif; ?>
         </div>

--- a/components/com_joomgallery/views/category/tmpl/bootone_images.php
+++ b/components/com_joomgallery/views/category/tmpl/bootone_images.php
@@ -84,48 +84,48 @@
               <li>
 <?php       if($this->params->get('show_download_icon') == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?task=download&id='.$row->id); ?>" class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT'); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
+                  <span class="icon-download"></span></a>
 <?php       endif;
             if($this->params->get('show_download_icon') == -1): ?>
                 <span class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT'); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
+                  <span class="icon-download"></span>
                 </span>
 <?php       endif;
             if($this->params->get('show_favourites_icon') == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimage&id='.$row->id.'&catid='.$row->catid); ?>" class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPTEXT', true); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'star.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php       endif;
             if($this->params->get('show_favourites_icon') == 2): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimage&id='.$row->id.'&catid='.$row->catid); ?>" class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPTEXT'); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php       endif;
             if($this->params->get('show_favourites_icon') == -1): ?>
                 <span class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_NOT_ALLOWED_TIPTEXT'); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'star_gr.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-star-empty"></span>
                 </span>
 <?php       endif;
             if($this->params->get('show_favourites_icon') == -2): ?>
                 <span class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_NOT_ALLOWED_TIPTEXT'); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-star-empty"></span>
                 </span>
 <?php       endif;
             if($this->params->get('show_report_icon') == 1):
               JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
                 <a href="<?php echo JRoute::_('index.php?view=report&id='.$row->id.'&catid='.$row->catid.'&tmpl=component'); ?>" class="hasTooltip jg-bootone-modal" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPTEXT'); ?>" rel="{handler:'iframe', size:{x:600,y:520}}"><!--, size:{x:200,y:200}-->
-                  <?php echo JHTML::_('joomgallery.icon', 'exclamation.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-notification-circle"></span></a>
       <?php endif;
             if($this->params->get('show_report_icon') == -1): ?>
                 <span class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_NOT_ALLOWED_TIPTEXT'); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'exclamation_gr.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-notification-circle"></span>
                 </span>
 <?php       endif;
             if($row->show_edit_icon): ?>
                 <a href="<?php echo JRoute::_('index.php?view=edit&id='.$row->id.$this->redirect); ?>" class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPTEXT'); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-edit"></span></a>
 <?php       endif;
             if($row->show_delete_icon): ?>
                 <a href="javascript:if(confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=image.delete&id='.$row->id.$this->redirect, false);?>';}" class="hasTooltip" title="<?php echo JHtml::_('tooltiptext', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPTEXT', true); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-delete"></span></a>
 <?php       endif; ?>
                 <?php echo $row->event->icons; ?>
               </li>

--- a/components/com_joomgallery/views/category/tmpl/bootone_subcategories.php
+++ b/components/com_joomgallery/views/category/tmpl/bootone_subcategories.php
@@ -27,15 +27,13 @@
         <div class="span2 text-right">
 <?php   if($this->params->get('show_feed_icon')): ?>
           <a href="<?php echo $this->params->get('feed_url'); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_CATEGORY_FEED_SUBCATEGORIES_TIPTEXT', 'COM_JOOMGALLERY_CATEGORY_FEED_TIPCAPTION', true); ?>>
-            <?php echo JHtml::_('joomgallery.icon', 'feed.png', 'COM_JOOMGALLERY_CATEGORY_FEED_TIPCAPTION'); ?>
-          </a>
+            <span class="icon-feed"></span></a>
 <?php     $this->params->set('show_feed_icon', 0);
         endif;
         if($this->params->get('show_upload_icon')):
           JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
           <a href="<?php echo JRoute::_('index.php?view=mini&format=raw&upload_category='.$this->category->cid); ?>" class="jg-bootone-modal<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPTEXT', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?>" rel="{handler: 'iframe', size: {x: 620, y: 550}}">
-            <?php echo JHtml::_('joomgallery.icon', 'add.png', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?>
-          </a>
+            <span class="icon-plus-circle"></span></a>
 <?php     $this->params->set('show_upload_icon', 0);
         endif; ?>
         </div>
@@ -54,8 +52,7 @@
         <div class="thumbnail">
 <?php     if($this->_config->get('jg_showsubthumbs') && $row->thumb_src): ?>
           <a title="<?php echo $row->name; ?>" href="<?php echo $row->link; ?>">
-            <img src="<?php echo $row->thumb_src; ?>" hspace="4" vspace="0" alt="<?php echo $row->name; ?>" />
-          </a>
+            <img src="<?php echo $row->thumb_src; ?>" hspace="4" vspace="0" alt="<?php echo $row->name; ?>" /></a>
 <?php     endif; ?>
           <div class="caption">
             <ul class="unstyled">
@@ -65,13 +62,13 @@
                   <h3><?php echo $this->escape($row->name); ?></h3></a>
 <?php       if($row->password && $this->_config->get('jg_showrestrictedhint')): ?>
                 <span<?php echo JHtml::_('joomgallery.tip', JText::_('COM_JOOMGALLERY_COMMON_CATEGORY_PASSWORD_PROTECTED_TIPTEXT'), JText::_('COM_JOOMGALLERY_COMMON_CATEGORY_PASSWORD_PROTECTED'), true); ?>>
-                  <?php echo JHtml::_('joomgallery.icon', 'key.png', 'COM_JOOMGALLERY_COMMON_CATEGORY_PASSWORD_PROTECTED'); ?>
+                  <span class="icon-key"></span>
                 </span>
 <?php       endif; ?>
 <?php     else: ?>
                 <span class="jg_no_access<?php echo JHTML::_('joomgallery.tip', JText::_('COM_JOOMGALLERY_COMMON_TIP_YOU_NOT_ACCESS_THIS_CATEGORY'), $this->escape($row->name), false, false); ?>">
                   <?php echo $this->escape($row->name); ?>
-                  <?php if($this->_config->get('jg_showrestrictedhint')): echo JHtml::_('joomgallery.icon', 'group_key.png', 'COM_JOOMGALLERY_COMMON_TIP_YOU_NOT_ACCESS_THIS_CATEGORY'); endif; ?>
+                  <?php if($this->_config->get('jg_showrestrictedhint')): ?><span class="icon-key"></span><?php endif; ?>
                 </span>
 <?php     endif; ?>
               </li>
@@ -100,20 +97,20 @@
               <li>
 <?php       if($row->show_favourites_icon == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimages&catid='.$row->cid.'&return='.$this->category->cid); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'star.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php       endif;
             if($row->show_favourites_icon == 2): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimages&catid='.$row->cid.'&return='.$this->category->cid); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php       endif;
             if($row->show_favourites_icon == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'star_gr.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION'); ?>
+                  <span class="Icon-star-empty"></span>
                 </span>
 <?php       endif;
             if($row->show_favourites_icon == -2): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION'); ?>
+                  <span class="Icon-star-empty"></span>
                 </span>
 <?php       endif; ?>
               </li>
@@ -122,7 +119,7 @@
             JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
               <li>
                 <a href="<?php echo JRoute::_('index.php?view=mini&format=raw&upload_category='.$row->cid); ?>" class="jg-bootone-modal<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPTEXT', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?>" rel="{handler: 'iframe', size: {x: 620, y: 550}}">
-                  <?php echo JHtml::_('joomgallery.icon', 'add.png', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?></a>
+                  <span class="icon-plus-circle"></span></a>
               </li>
 <?php     endif; ?>
             </ul>

--- a/components/com_joomgallery/views/detail/tmpl/bootone.php
+++ b/components/com_joomgallery/views/detail/tmpl/bootone.php
@@ -58,18 +58,18 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
   <div class="hidden" id="jg-slideshow-controls">
 <?php   if(!$this->slideshow): ?>
     <a href="javascript:joom_startslideshow()"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW_START', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW', true); ?>>
-      <?php echo JHTML::_('joomgallery.icon', 'control_play.png', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW_START'); ?></a>
+      <span class="icon-play-circle"></span></a>
     <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW_STOP', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW', true); ?>>
-      <?php echo JHTML::_('joomgallery.icon', 'control_stop_gr.png', 'COM_JOOMGALLERY_DETAIL_IMG_FULLSIZE_TIPCAPTION'); ?>
+        <span class="icon-stop-circle"></span>
     </span>
 <?php   endif;
         if($this->slideshow): ?>
     <a href="javascript:joom_slideshow.clearTimer()" id="jg_pause"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW_PAUSE', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW', true); ?>>
-      <?php echo JHTML::_('joomgallery.icon', 'control_pause.png', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW_PAUSE'); ?></a>
+        <span class="icon-pause-circle"></span></a>
     <a href="javascript:joom_slideshow.nextItem();joom_slideshow.prepareTimer();" id="jg_goon">
-      <?php echo JHTML::_('joomgallery.icon', 'control_play.png', 'COM_JOOMGALLERY_GOON'); ?></a>
+        <span class="icon-play-circle"></span></a>
     <a href="javascript:joom_stopslideshow()"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW_STOP', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW', true); ?>>
-      <?php echo JHTML::_('joomgallery.icon', 'control_stop.png', 'COM_JOOMGALLERY_DETAIL_SLIDESHOW_STOP'); ?></a>
+        <span class="icon-stop-circle"></span></a>
 <?php   endif; ?>
   </div>
   <div class="text-center text-muted small" id="jg-slideshow-noscript">
@@ -100,76 +100,76 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
     </div>
     <div class="span6 jg-iconbar text-center">
 <?php if($this->params->get('show_zoom_icon') == 1): ?>
-      <a <?php echo $this->image->atagtitle; ?> href="<?php echo $this->params->get('image_linked') ? JHtml::_('joomgallery.openimage', $this->_config->get('jg_bigpic_open'), $this->image, false, 'joomgalleryIcon') : $this->image->link; ?>"<?php //echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_IMG_FULLSIZE_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_IMG_FULLSIZE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'zoom.png', 'COM_JOOMGALLERY_DETAIL_IMG_FULLSIZE_TIPCAPTION'); ?></a>
+      <a <?php echo $this->image->atagtitle; ?> href="<?php echo $this->params->get('image_linked') ? JHtml::_('joomgallery.openimage', $this->_config->get('jg_bigpic_open'), $this->image, false, 'joomgalleryIcon') : $this->image->link; ?>">
+        <span class="icon-zoom-in"></span></a>
 <?php endif;
       if($this->params->get('show_zoom_icon') == -1): ?>
       <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_IMG_FULLSIZE_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_IMG_FULLSIZE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'zoom_gr.png', 'COM_JOOMGALLERY_DETAIL_IMG_FULLSIZE_TIPCAPTION'); ?>
+        <span class="icon-zoom-in"></span>
       </span>
 <?php endif;
       if($this->params->get('show_download_icon') == 1): ?>
       <a href="<?php echo $this->params->get('download_link'); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
+        <span class="icon-download"></span></a>
 <?php endif;
       if($this->params->get('show_download_icon') == -1): ?>
       <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
+        <span class="icon-download"></span>
       </span>
 <?php endif;
       if($this->params->get('show_nametag_icon') == 1): ?>
       <a href="javascript:joom_getcoordinates();"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'tag_add.png', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_TIPCAPTION'); ?></a>
+        <span class="icon-tag-2"></span></a>
 <?php endif;
       if($this->params->get('show_nametag_icon') == 2): ?>
       <a href="javascript:if(confirm('<?php echo JText::_('COM_JOOMGALLERY_DETAIL_NAMETAGS_ALERT_SURE_DELETE', true); ?>')){ location.href='<?php echo $this->params->get('nametag_link'); ?>';}"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_DELETE_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_DELETE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'tag_delete.png', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_DELETE_TIPCAPTION'); ?></a>
+        <span class="icon-tag-2"></span></a>
 <?php endif;
       if($this->params->get('show_nametag_icon') == 3):
         JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
       <a href="<?php echo JRoute::_('index.php?view=nametag&tmpl=component'); ?>" class="jg-bootone-modal<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_SELECT_OTHERS_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_SELECT_OTHERS_TIPCAPTION'); ?>" rel="{handler:'iframe', size:{x:350,y:180}}">
-        <?php echo JHTML::_('joomgallery.icon', 'tag_edit.png', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_SELECT_OTHERS_TIPCAPTION'); ?></a>
+        <span class="icon-tag-2"></span></a>
 <?php endif;
       if($this->params->get('show_nametag_icon') == -1): ?>
       <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_UNREGISTERED_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_UNREGISTERED_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'tag_add_gr.png', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_UNREGISTERED_TIPCAPTION'); ?>
+        <span class="icon-tag-2"></span>
       </span>
 <?php endif;
       if($this->params->get('show_favourites_icon') == 1): ?>
       <a href="<?php echo $this->params->get('favourites_link'); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'star.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION'); ?></a>
+        <span class="icon-star"></span></a>
 <?php endif;
       if($this->params->get('show_favourites_icon') == -1): ?>
       <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'star_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
+        <span class="icon-star-empty"></span>
       </span>
 <?php endif;
       if($this->params->get('show_favourites_icon') == 2): ?>
       <a href="<?php echo $this->params->get('favourites_link'); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'basket_put.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?></a>
+        <span class="icon-star"></span></a>
 <?php endif;
       if($this->params->get('show_favourites_icon') == -2): ?>
       <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'basket_put_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?>
+        <span class="icon-star-empty"></span>
       </span>
 <?php endif;
       if($this->params->get('show_report_icon') == 1):
         JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
       <a href="<?php echo JRoute::_('index.php?view=report&id='.$this->image->id.'&tmpl=component'); ?>" class="jg-bootone-modal<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?>" rel="{handler:'iframe'}"><!--, size:{x:200,y:100}-->
-        <?php echo JHTML::_('joomgallery.icon', 'exclamation.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?></a>
+        <span class="icon-notification-circle"></span></a>
 <?php endif;
       if($this->params->get('show_report_icon') == -1): ?>
       <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'exclamation_gr.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?>
+        <span class="icon-notification-circle"></span>
       </span>
 <?php endif; ?>
 <?php if($this->params->get('show_edit_icon')) : ?>
       <a href="<?php echo JRoute::_('index.php?view=edit&id='.$this->image->id.$this->redirect); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION'); ?></a>
+        <span class="icon-edit"></span></a>
 <?php endif;
       if($this->params->get('show_delete_icon')): ?>
       <a href="javascript:if(confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=image.delete&id='.$this->image->id, false);?>';}"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION', true); ?>>
-        <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION'); ?></a>
+        <span class="icon-delete"></span></a>
 <?php endif; ?>
       <?php echo $this->event->icons; ?>
     </div>
@@ -732,7 +732,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
   </div>
 <?php if($this->params->get('show_nametags')): ?>
   <a id="jg-movable-nametag-icon" href="javascript:joom_getcoordinates();" class="jg_displaynone<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_OTHERS_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_OTHERS_TIPCAPTION'); ?>">
-    <?php echo JHTML::_('joomgallery.icon', 'tag_add.png', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_OTHERS_TIPCAPTION'); ?>
+    <span class="icon-tag-2"></span>
   </a>
   <span id="jg-tooltip-helper" class="jg_displaynone<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_DELETE_OTHERS_TIPTEXT', 'COM_JOOMGALLERY_DETAIL_NAMETAGS_DELETE_OTHERS_TIPCAPTION'); ?>">&nbsp;</span>
   <script type="text/javascript">

--- a/components/com_joomgallery/views/favourites/tmpl/bootone.php
+++ b/components/com_joomgallery/views/favourites/tmpl/bootone.php
@@ -8,15 +8,14 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
         </div>
         <div class="span2">
           <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=favourites.removeall'); ?>">
-            <?php echo JText::_('COM_JOOMGALLERY_FAVOURITES_REMOVE_ALL'); ?>
-          </a>
+            <?php echo JText::_('COM_JOOMGALLERY_FAVOURITES_REMOVE_ALL'); ?></a>
         </div>
       </div>
     </div>
 <?php if(!$count = count($this->rows)): ?>
     <div class="row-fluid">
       <div class="span12">
-        <?php echo JHTML::_('joomgallery.icon', 'arrow.png', 'arrow'); ?>
+        <span class="icon-arrow-right-4"></span>
         <?php echo $this->output('NO_IMAGES'); ?>
       </div>
     </div>
@@ -31,8 +30,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
       <li class="span<?php echo (int) (12 / $this->_config->get('jg_toplistcols')); ?>">
         <div class="thumbnail">
           <a href="<?php echo $row->link; ?>" <?php echo $row->atagtitle; ?>>
-            <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->imgtitle; ?>" />
-          </a>
+            <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->imgtitle; ?>" /></a>
           <div class="caption">
             <ul class="unstyled text-center">
               <li>
@@ -41,8 +39,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
               <li>
                 <?php echo JText::_('COM_JOOMGALLERY_COMMON_CATEGORY'); ?>
                 <a href="<?php echo JRoute::_('index.php?view=category&catid='.$row->catid); ?>">
-                  <?php echo $row->name; ?>
-                </a>
+                  <?php echo $row->name; ?></a>
               </li>
 <?php     if($this->_config->get('jg_showauthor')): ?>
               <li>
@@ -85,22 +82,22 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
               <li>
 <?php     if($this->params->get('show_download_icon') == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=download&id='.$row->id); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
+                  <span class="icon-download"></span></a>
 <?php     endif;
           if($this->params->get('show_download_icon') == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
+                  <span class="icon-download"></span>
                 </span>
 <?php     endif; ?>
                 <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=favourites.removeimage&id='.$row->id); ?>"<?php echo JHTML::_('joomgallery.tip', $this->output('REMOVE_TIPTEXT'), $this->output('REMOVE_TIPCAPTION'), true, false); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_remove.png', $this->output('REMOVE_TIPCAPTION'), null, null, false); ?></a>
+                  <span class="icon-box-remove"></span></a>
 <?php     if($row->show_edit_icon): ?>
                 <a href="<?php echo JRoute::_('index.php?view=edit&id='.$row->id.$this->redirect); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-edit"></span></a>
 <?php     endif;
           if($row->show_delete_icon): ?>
                 <a href="javascript:if(confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=image.delete&id='.$row->id.$this->redirect, false);?>';}"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-delete"></span></a>
 <?php     endif; ?>
               </li>
             </ul>

--- a/components/com_joomgallery/views/gallery/tmpl/bootone.php
+++ b/components/com_joomgallery/views/gallery/tmpl/bootone.php
@@ -34,25 +34,23 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
       <div class="thumbnail">
 <?php     if($row->thumb_src): ?>
         <a title="<?php echo $row->name; ?>" href="<?php echo $row->link ?>">
-          <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->name; ?>" />
-        </a>
+          <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->name; ?>" /></a>
 <?php     endif; ?>
       <div class="caption">
         <ul class="unstyled">
           <li>
 <?php     if(in_array($row->access, $this->_user->getAuthorisedViewLevels())): ?>
             <a href="<?php echo $row->link; ?>">
-              <h3><?php echo $this->escape($row->name); ?></h3>
-            </a>
+              <h3><?php echo $this->escape($row->name); ?></h3></a>
 <?php       if($row->password && $this->_config->get('jg_showrestrictedhint')): ?>
             <span<?php echo JHtml::_('joomgallery.tip', JText::_('COM_JOOMGALLERY_COMMON_CATEGORY_PASSWORD_PROTECTED_TIPTEXT'), JText::_('COM_JOOMGALLERY_COMMON_CATEGORY_PASSWORD_PROTECTED'), true); ?>>
-              <?php echo JHtml::_('joomgallery.icon', 'key.png', 'COM_JOOMGALLERY_COMMON_CATEGORY_PASSWORD_PROTECTED'); ?>
+              <span class="icon-key"></span>
             </span>
 <?php       endif; ?>
 <?php     else: ?>
             <span class="jg_no_access<?php echo JHTML::_('joomgallery.tip', JText::_('COM_JOOMGALLERY_COMMON_TIP_YOU_NOT_ACCESS_THIS_CATEGORY'), $this->escape($row->name), false, false); ?>">
               <h3><?php echo $this->escape($row->name); ?></h3>
-              <?php if($this->_config->get('jg_showrestrictedhint')): echo JHtml::_('joomgallery.icon', 'group_key.png', 'COM_JOOMGALLERY_COMMON_TIP_YOU_NOT_ACCESS_THIS_CATEGORY'); endif; ?>
+              <?php if($this->_config->get('jg_showrestrictedhint')): ?><span class="icon-key"></span><?php endif; ?>
             </span>
 <?php     endif; ?>
           </li>
@@ -81,20 +79,20 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
           <li>
 <?php       if($row->show_favourites_icon == 1): ?>
             <a href="<?php echo JRoute::_('index.php?task=favourites.addimages&catid='.$row->cid.'&return=gallery'); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION', true); ?>>
-              <?php echo JHTML::_('joomgallery.icon', 'star.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION'); ?></a>
+              <span class="icon-star"></span></a>
 <?php       endif;
             if($row->show_favourites_icon == 2): ?>
             <a href="<?php echo JRoute::_('index.php?task=favourites.addimages&catid='.$row->cid.'&return=gallery'); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION', true); ?>>
-              <?php echo JHTML::_('joomgallery.icon', 'basket_put.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION'); ?></a>
+              <span class="icon-star"></span></a>
 <?php       endif;
             if($row->show_favourites_icon == -1): ?>
             <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION', true); ?>>
-              <?php echo JHTML::_('joomgallery.icon', 'star_gr.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGES_TIPCAPTION'); ?>
+              <span class="icon-star-empty"></span>
             </span>
 <?php       endif;
             if($row->show_favourites_icon == -2): ?>
             <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION', true); ?>>
-              <?php echo JHTML::_('joomgallery.icon', 'basket_put_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGES_TIPCAPTION'); ?>
+              <span class="icon-star-empty"></span>
             </span>
 <?php       endif; ?>
           </li>
@@ -103,7 +101,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
             JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
             <li>
               <a href="<?php echo JRoute::_('index.php?view=mini&format=raw&upload_category='.$row->cid); ?>" class="jg-bootone-modal<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPTEXT', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?>" rel="{handler: 'iframe', size: {x: 620, y: 550}}">
-                <?php echo JHtml::_('joomgallery.icon', 'add.png', 'COM_JOOMGALLERY_COMMON_UPLOAD_ICON_TIPCAPTION'); ?></a>
+                <span class="icon-plus-circle"></span></a>
             </li>
 <?php     endif; ?>
         </ul>

--- a/components/com_joomgallery/views/search/tmpl/bootone.php
+++ b/components/com_joomgallery/views/search/tmpl/bootone.php
@@ -10,7 +10,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
       if(!$count): ?>
     <div class="row-fluid">
       <div class="span12">
-        <?php echo JHTML::_('joomgallery.icon', 'arrow.png', 'arrow'); ?>
+        <span class="icon-arrow-right-4"></span>
         <?php echo JText::_('COM_JOOMGALLERY_SEARCH_RESULTS_NO_IMAGES'); ?>
       </div>
     </div>
@@ -23,8 +23,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
       <li class="span<?php echo (int) (12 / $this->_config->get('jg_searchcols')); ?>">
         <div class="thumbnail">
           <a <?php echo $row->atagtitle; ?> href="<?php echo $row->link; ?>">
-            <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->imgtitle; ?>" />
-          </a>
+            <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->imgtitle; ?>" /></a>
           <div class="caption">
             <ul class="unstyled text-center">
               <li>
@@ -33,8 +32,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
               <li>
                 <?php echo JText::_('COM_JOOMGALLERY_COMMON_CATEGORY'); ?>
                 <a href="<?php echo JRoute::_('index.php?view=category&catid='.$row->catid); ?>">
-                  <?php echo $row->name; ?>
-                </a>
+                  <?php echo $row->name; ?></a>
               </li>
 <?php     if($this->_config->get('jg_showauthor')): ?>
               <li>
@@ -77,48 +75,48 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
               <li>
 <?php     if($this->params->get('show_download_icon') == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=download&id='.$row->id); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
+                  <span class="icon-download"></span></a>
 <?php     endif;
           if($this->params->get('show_download_icon') == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
+                  <span class="icon-download"></span>
                 </span>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimage&id='.$row->id.'&sstring='.$this->sstring); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'star.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == 2): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimage&id='.$row->id.'&sstring='.$this->sstring); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'star_gr.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-star-empty"></span>
                 </span>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == -2): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-star-empty"></span>
                 </span>
 <?php     endif;
           if($this->params->get('show_report_icon') == 1):
             JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
                 <a href="<?php echo JRoute::_('index.php?view=report&id='.$row->id.'&sstring='.$this->sstring.'&tmpl=component'); ?>" class="jg-bootone-modal<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?>" rel="{handler:'iframe'}"><!--, size:{x:200,y:100}-->
-                  <?php echo JHTML::_('joomgallery.icon', 'exclamation.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-notification-circle"></span></a>
 <?php     endif;
           if($this->params->get('show_report_icon') == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'exclamation_gr.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-notification-circle"></span>
                 </span>
 <?php     endif;
           if($row->show_edit_icon): ?>
                 <a href="<?php echo JRoute::_('index.php?view=edit&id='.$row->id.$this->redirect); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-edit"></span></a>
 <?php     endif;
           if($row->show_delete_icon): ?>
                 <a href="javascript:if(confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=image.delete&id='.$row->id.$this->redirect, false);?>';}"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-delete"></span></a>
 <?php     endif;
           $results = $this->_mainframe->triggerEvent('onJoomDisplayIcons', array('search.image', $row));
           echo implode('', $results) ?>

--- a/components/com_joomgallery/views/toplist/tmpl/bootone.php
+++ b/components/com_joomgallery/views/toplist/tmpl/bootone.php
@@ -11,7 +11,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
       if(!$count): ?>
     <div class="row-fluid">
       <div class="span12">
-        <?php echo JHTML::_('joomgallery.icon', 'arrow.png', 'arrow'); ?>
+        <span class="icon-arrow-right-4"></span>
         <?php echo JText::_('COM_JOOMGALLERY_TOPLIST_NO_IMAGES'); ?>
       </div>
     </div>
@@ -24,8 +24,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
       <li class="span<?php echo (int) (12 / $this->_config->get('jg_toplistcols')); ?>">
         <div class="thumbnail">
           <a <?php echo $row->atagtitle; ?> href="<?php echo $row->link; ?>">
-            <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->imgtitle; ?>" />
-          </a>
+            <img src="<?php echo $row->thumb_src; ?>" alt="<?php echo $row->imgtitle; ?>" /></a>
           <div class="caption">
             <ul class="unstyled text-center">
               <li>
@@ -34,8 +33,7 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
               <li>
                 <?php echo JText::_('COM_JOOMGALLERY_COMMON_CATEGORY'); ?>
                 <a href="<?php echo JRoute::_('index.php?view=category&catid='.$row->catid); ?>">
-                  <?php echo $row->name; ?>
-                </a>
+                  <?php echo $row->name; ?></a>
               </li>
 <?php     if($this->_config->get('jg_showauthor')): ?>
               <li>
@@ -78,48 +76,48 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
               <li>
 <?php     if($this->params->get('show_download_icon') == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=download&id='.$row->id); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
+                  <span class="icon-download"></span></a>
 <?php     endif;
           if($this->params->get('show_download_icon') == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
+                  <span class="icon-download"></span>
                 </span>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == 1): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimage&id='.$row->id.'&toplist='.$this->type); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'star.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == 2): ?>
                 <a href="<?php echo JRoute::_('index.php?task=favourites.addimage&id='.$row->id.'&toplist='.$this->type); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-star"></span></a>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'star_gr.png', 'COM_JOOMGALLERY_COMMON_FAVOURITES_ADD_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-star-empty"></span>
                 </span>
 <?php     endif;
           if($this->params->get('show_favourites_icon') == -2): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'basket_put_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOADZIP_ADD_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-star-empty"></span>
                 </span>
 <?php     endif;
           if($this->params->get('show_report_icon') == 1):
             JHtml::_('behavior.modal', '.jg-bootone-modal'); ?>
                 <a href="<?php echo JRoute::_('index.php?view=report&id='.$row->id.'&toplist='.$this->type.'&tmpl=component'); ?>" class="jg-bootone-modal<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?>" rel="{handler:'iframe'}"><!--, size:{x:200,y:100}-->
-                  <?php echo JHTML::_('joomgallery.icon', 'exclamation.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-notification-circle"></span></a>
 <?php     endif;
           if($this->params->get('show_report_icon') == -1): ?>
                 <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_NOT_ALLOWED_TIPTEXT', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'exclamation_gr.png', 'COM_JOOMGALLERY_COMMON_REPORT_IMAGE_TIPCAPTION'); ?>
+                  <span class="icon-notification-circle"></span>
                 </span>
 <?php     endif;
           if($row->show_edit_icon): ?>
                 <a href="<?php echo JRoute::_('index.php?view=edit&id='.$row->id.$this->redirect); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-edit"></span></a>
 <?php     endif;
           if($row->show_delete_icon): ?>
                 <a href="javascript:if(confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=image.delete&id='.$row->id.$this->redirect, false);?>';}"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION', true); ?>>
-                  <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION'); ?></a>
+                  <span class="icon-delete"></span></a>
 <?php     endif;
           $results = $this->_mainframe->triggerEvent('onJoomDisplayIcons', array('toplist.image', $row));
           echo implode('', $results) ?>

--- a/components/com_joomgallery/views/usercategories/tmpl/bootone.php
+++ b/components/com_joomgallery/views/usercategories/tmpl/bootone.php
@@ -208,20 +208,20 @@ $sortFields = $this->getSortFields();
 <?php       if($canEdit || $canEditOwn): ?>
               <div class="pull-left<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_EDIT_CATEGORY_TIPTEXT', 'COM_JOOMGALLERY_COMMON_EDIT_CATEGORY_TIPCAPTION'); ?>">
                 <a href="<?php echo JRoute::_('index.php?view=editcategory&catid='.$item->cid.$this->slimitstart); ?>">
-                  <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_CATEGORY_TIPCAPTION'); ?></a>
+                  <span class="icon-edit"></span></a>
               </div>
 <?php       endif;
             if($canDelete && !$item->children && !$item->images): ?>
               <div class="pull-left<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DELETE_CATEGORY_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DELETE_CATEGORY_TIPCAPTION'); ?>">
                 <a href="javascript:if (confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=category.delete&catid='.$item->cid.$this->slimitstart, false); ?>';}">
-                  <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE'); ?></a>
+                  <span class="icon-delete"></span></a>
               </div>
 <?php       endif; ?>
             </td>
             <td class=center>
-<?php         $p_img    = 'cross';
+<?php         $p_img = 'icon-unpublish';
               if($item->published):
-                $p_img = 'tick';
+                $p_img = 'icon-publish';
               endif;
               if($canChange):
                 $p_title  = JText::_('COM_JOOMGALLERY_COMMON_PUBLISH_CATEGORY_TIPCAPTION');
@@ -231,14 +231,14 @@ $sortFields = $this->getSortFields();
                   $p_text  = JText::_('COM_JOOMGALLERY_COMMON_UNPUBLISH_CATEGORY_TIPTEXT');
                 endif; ?>
               <a href="<?php echo JRoute::_('index.php?task=category.publish&catid='.$item->cid.$this->slimitstart); ?>"<?php echo JHTML::_('joomgallery.tip', $p_text, $p_title, true, false); ?>>
-                <?php echo JHTML::_('joomgallery.icon', $p_img.'.png', $p_img); ?></a>
+                <span class="<?php echo $p_img; ?>"></span></a>
 <?php         else:
                 $p_title  = JText::_('COM_JOOMGALLERY_COMMON_UNPUBLISHED');
                 if($item->published):
                   $p_title = JText::_('COM_JOOMGALLERY_COMMON_PUBLISHED');
                 endif; ?>
               <div class="<?php echo JHTML::_('joomgallery.tip', '', $p_title); ?>">
-                <?php echo JHTML::_('joomgallery.icon', $p_img.'.png', $p_img, null, null, false); ?>
+                <span class="<?php echo $p_img; ?>"></span>
               </div>
 <?php         endif;
               if($item->published && $item->hidden):

--- a/components/com_joomgallery/views/userpanel/tmpl/bootone.php
+++ b/components/com_joomgallery/views/userpanel/tmpl/bootone.php
@@ -190,20 +190,20 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
 <?php       if($item->show_edit_icon): ?>
             <div class="pull-left<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_EDIT_IMAGE_TIPCAPTION'); ?>">
               <a href="<?php echo JRoute::_('index.php?view=edit&id='.$item->id.$this->slimitstart); ?>">
-                <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_CATEGORY_TIPCAPTION'); ?></a>
+                <span class="icon-edit"></span></a>
             </div>
 <?php       endif;
             if($item->show_delete_icon): ?>
             <div class="pull-left<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DELETE_IMAGE_TIPCAPTION'); ?>">
               <a href="javascript:if(confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=image.delete&id='.$item->id.$this->slimitstart, false);?>';}">
-                <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE'); ?></a>
+                <span class="icon-delete"></span></a>
             </div>
 <?php       endif; ?>
           </td>
           <td class="nowrap center">
-<?php       $p_img    = 'cross';
+<?php       $p_img = 'icon-unpublish';
             if($item->published):
-              $p_img = 'tick';
+              $p_img = 'icon-publish';
             endif; ?>
 <?php       if($canChange):
               $p_title  = JText::_('COM_JOOMGALLERY_COMMON_PUBLISH_IMAGE_TIPCAPTION');
@@ -213,14 +213,14 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
                 $p_text  = JText::_('COM_JOOMGALLERY_COMMON_UNPUBLISH_IMAGE_TIPTEXT');
               endif; ?>
             <a href="<?php echo JRoute::_('index.php?task=image.publish&id='.$item->id.$this->slimitstart); ?>"<?php echo JHTML::_('joomgallery.tip', $p_text, $p_title, true, false); ?>>
-              <?php echo JHTML::_('joomgallery.icon', $p_img.'.png', $p_img, null, null, false); ?></a>
+              <span class="<?php echo $p_img; ?>"></span></a>
 <?php       else:
               $p_title  = JText::_('COM_JOOMGALLERY_COMMON_UNPUBLISHED');
               if($item->published):
                 $p_title = JText::_('COM_JOOMGALLERY_COMMON_PUBLISHED');
               endif; ?>
             <div class="<?php echo JHTML::_('joomgallery.tip', '', $p_title); ?>">
-              <?php echo JHTML::_('joomgallery.icon', $p_img.'.png', $p_img, null, null, false); ?>
+              <span class="<?php echo $p_img; ?>"></span>
             </div>
 <?php       endif;
             if($item->published && $item->hidden):
@@ -232,14 +232,14 @@ echo JLayoutHelper::render('joomgallery.common.header', $this, '', array('suffix
           </td>
 <?php     if($this->_config->get('jg_approve')): ?>
           <td class="nowrap center">
-<?php       $a_img = 'cross';
+<?php       $a_img = 'icon-unpublish';
             $a_title = 'COM_JOOMGALLERY_COMMON_REJECTED';
             if($item->approved == 1):
-              $a_img = 'tick';
+              $a_img = 'icon-publish';
               $a_title = 'COM_JOOMGALLERY_COMMON_APPROVED';
             endif; ?>
             <div class="<?php echo JHTML::_('joomgallery.tip', '', $a_title); ?>">
-              <?php echo JHTML::_('joomgallery.icon', $a_img.'.png', $a_img, null, null, false); ?>
+              <span class="<?php echo $a_img; ?>"></span>
             </div>
           </td>
 <?php     endif?>


### PR DESCRIPTION
Replace images with icomoon fonts like also desired here: https://github.com/JoomGallery/JoomGallery/issues/109
As far as I understand, the corresponding css classes must be entered into the template files.
Here is a suggestion where the images were replaced by the icomoon fonts from Joomla. List of Joomla icons: https://docs.joomla.org/J3.x:Joomla_Standard_Icomoon_Fonts
Unfortunately, there is no full equal-looking icon for all images used so far. I hope the icons are used as clear and understandable. 
Suggestions for improvements are welcome.